### PR TITLE
Update gpnf-limit-entry-min-max-from-field.php

### DIFF
--- a/gp-nested-forms/gpnf-limit-entry-min-max-from-field.php
+++ b/gp-nested-forms/gpnf-limit-entry-min-max-from-field.php
@@ -4,6 +4,7 @@
  * http://gravitywiz.com/documentation/gravity-forms-nested-forms/
  */
 class GP_Nested_Forms_Dynamic_Entry_Min_Max {
+    private $_args;
 
 	public function __construct( $args = array() ) {
 
@@ -131,7 +132,8 @@ class GP_Nested_Forms_Dynamic_Entry_Min_Max {
 
 					self.init = function () {
 
-						var attrReadyMaxFieldId = self.maxFieldId.replace( '.', '_' );
+						var attrReadyMaxFieldId = String(self.maxFieldId).replace('.', '_');
+
 						var maxFieldId = 'input_' + self.parentFormId + '_' + attrReadyMaxFieldId;
 
 						// GF uses "1" for the input index in the HTML id attribute for Single Product fields. Weird.


### PR DESCRIPTION
Fix these two errors:
1. Creation of dynamic property GP_Nested_Forms_Dynamic_Entry_Min_Max::$_args is deprecated

2. Uncaught TypeError: self.maxFieldId.replace is not a function

## Context

<!-- Add the appropriate ticket(s), Notion card, and/or Slack conversation if available. Delete any unused lines. -->

⛑️ Ticket(s): https://secure.helpscout.net/link/to/conversation

📓 Notion: https://notion.so/link/to/card

💬 Slack: https://slack.com/link/to/thread-or-message

## Summary

<!-- Briefly explain what's new in this pull request. -->
